### PR TITLE
ff fixes

### DIFF
--- a/gold-phone-input.html
+++ b/gold-phone-input.html
@@ -66,6 +66,7 @@ Example:
           bind-value="{{value}}"
           name$="[[name]]"
           allowed-pattern="[0-9]"
+          autocomplete$="[[autocomplete]]"
           prevent-invalid-input>
       </div>
 


### PR DESCRIPTION
This fixes:
- inputs have a min width in Firefox, which means input was squished next to the country code
- NVDA on Firefox reads "autocomplete" if the attribute isn't set