### PR TITLE
add autocomplete field

### DIFF
--- a/gold-phone-input.html
+++ b/gold-phone-input.html
@@ -86,7 +86,7 @@ style this element.
           bind-value="{{value}}"
           name$="[[name]]"
           allowed-pattern="[0-9]"
-          autocomplete$="[[autocomplete]]"
+          autocomplete="tel"
           prevent-invalid-input>
       </div>
 


### PR DESCRIPTION
Apparently the `autocomplete` field has meaning. See: https://developers.google.com/web/fundamentals/input/form/label-and-name-inputs?hl=en

It worked by magic in some of the elements because they had a heuristic-approved name in the demo, but now it works regardless of the name.

/cc @morethanreal @cdata 
