### PR TITLE
fix label padding

### DIFF
--- a/gold-phone-input.html
+++ b/gold-phone-input.html
@@ -69,6 +69,13 @@ style this element.
     width: 40px;
   }
 
+  /* TODO(notwaldorf): The style applied by paper-input-container is more
+   * specific, and we need the important to override it. This will go away
+   * once we can refactor this element to use the paper-input suffix */
+  label {
+    left: 40px !important;
+  }
+
   </style>
 
   <template>
@@ -78,7 +85,7 @@ style this element.
         always-float-label="[[_computeAlwaysFloatLabel(alwaysFloatLabel,placeholder)]]"
         invalid="[[invalid]]">
 
-      <label style="left:40px;" hidden$="[[!label]]">[[label]]</label>
+      <label hidden$="[[!label]]">[[label]]</label>
 
       <div class="horizontal layout">
         <span>+<span>[[countryCode]]</span></span>


### PR DESCRIPTION
This was broken by https://github.com/PolymerElements/paper-input/pull/119, I think. In any case, inspecting leads to a super specific style that I don't see how we can override without `!important`

Good news: this will all go away in the Major Template Reusing and Refactor of 2015.

@cdata PTAL