### PR TITLE
minor fixes

### DIFF
--- a/gold-phone-input.html
+++ b/gold-phone-input.html
@@ -106,6 +106,7 @@ style this element.
           inputmode$="[[inputmode]]"
           placeholder$="[[placeholder]]"
           readonly$="[[readonly]]"
+          maxlength$="[[maxlength]]"
           size$="[[size]]">
       </div>
 
@@ -176,7 +177,7 @@ style this element.
 
     _computeValue: function(value) {
       var start = this.$.input.selectionStart;
-      var previousCharADash = this.value.charAt(start - 1) == '-';
+      var previousCharADash = this.value ? this.value.charAt(start - 1) == '-' : false;
 
       // Remove any already-applied formatting.
       value = value.replace(/-/g, '');


### PR DESCRIPTION
- passes `maxlength` to the iron-input, which fixes https://github.com/PolymerElements/gold-phone-input/issues/24, https://github.com/PolymerElements/gold-phone-input/issues/20
- null-checks the value before poking at its formatting, which fixes https://github.com/PolymerElements/gold-phone-input/issues/23, 

@cdata PTAL
