### PR TITLE
Retrieve phone number with +countrycode but without pattern

### DIFF
--- a/gold-phone-input.html
+++ b/gold-phone-input.html
@@ -181,6 +181,14 @@ style this element.
       this.$.input.pattern = regex;
     },
 
+    _phoneNumberNoPatterns: function() {
+      var regex = '';
+      regex = this.value.replace(/[^0-9 ]/g, "");
+
+      var phoneNumberNoPatterns = '+' + this.countryCode + regex;
+      return phoneNumberNoPatterns;
+    },
+
     /**
      * A handler that is called on input
      */


### PR DESCRIPTION
gold-phone doesn't give you the actual phone number with .value. If for example I want to use the number to store it in my database or push it directly to the twilio SMS api I first need to make the conversion to get the proper number with '+'  + countrycode + valueWithoutDashes

Useless value: 1-23-12-32-11
Useful value: +63123123211

This is my first pull request ever, I hope I've done the pull request properly.