### PR TITLE
Workaround unexpected caret behavior

### DIFF
--- a/gold-phone-input.html
+++ b/gold-phone-input.html
@@ -194,7 +194,7 @@ style this element.
 
       // Remove any already-applied formatting.
       value = value.replace(/-/g, '');
-      var shouldFormat = value.length <= this.phoneNumberPattern.replace(/-/g, '').length;
+      var shouldFormat = true;
       var formattedValue = '';
 
       // Fill in the dashes according to the specified pattern.

--- a/gold-phone-input.html
+++ b/gold-phone-input.html
@@ -194,7 +194,6 @@ style this element.
 
       // Remove any already-applied formatting.
       value = value.replace(/-/g, '');
-      var shouldFormat = true;
       var formattedValue = '';
 
       // Fill in the dashes according to the specified pattern.
@@ -205,7 +204,7 @@ style this element.
 
         // Since we remove any formatting first, we need to account added dashes
         // when counting the position of new dashes in the pattern.
-        if (shouldFormat && i == (currentDashIndex - totalDashesAdded)) {
+        if (i == (currentDashIndex - totalDashesAdded)) {
           formattedValue += '-';
           currentDashIndex++;
           totalDashesAdded++;


### PR DESCRIPTION
As seen on issue #18 

An option to workaround the unexpected caret behavior when erasing a character from the input when its length == pattern.length+1.

