### PR TITLE
Allowing chrome autofill to complete phone number, if phone number includes country code.

### DIFF
--- a/gold-phone-input.html
+++ b/gold-phone-input.html
@@ -202,6 +202,7 @@ style this element.
 
       //Ensure value is a string
       value = value ? value.toString() : '';
+      value = value.replace("+" + this.countryCode, "");
 
       // Keep track of how many dashes the original value has. After
       // reformatting the value, we might gain or lose some of them, which


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/2510560/15470224/f4726032-210c-11e6-8053-f4ff3c819ac7.png)

Currently it doesn't allow phone number to auto fill.

Trying to take care of extra country code part in _onValueChanged event.