### PR TITLE
Expose international format value

### DIFF
--- a/gold-phone-input.html
+++ b/gold-phone-input.html
@@ -170,6 +170,16 @@ style this element.
       value: {
         type: String,
         observer: '_onValueChanged'
+      },
+
+      /**
+       * International format of the input value.
+       *
+       * @type {String}
+       */
+      internationalValue: {
+        type: String,
+        computed: '_computeInternationalValue(countryCode, value)'
       }
     },
 
@@ -267,6 +277,16 @@ style this element.
       if (!focused) {
         this._handleAutoValidate();
       }
+    },
+
+    /**
+     * Returns the phone number value prefixed by the country code or simply
+     * the value if the country code is not set. When	`value` equals
+     * "3-44-55-66-77" and the `countryCode` is "33", the `internationalValue`
+     * equals "+(33)3-44-55-66-77"
+     */
+    _computeInternationalValue: function(countryCode, value) {
+      return countryCode ? '+(' + countryCode + ')' + value : value;
     }
   });
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -101,6 +101,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is not visibility:hidden');
         assert.isTrue(container.invalid);
       });
+
+      test('international value properly computed', function() {
+        var input = fixture('basic');
+        input.countryCode = '33';
+        input.phoneNumberPattern = 'X-XX-XX-XX-XX';
+        input.value = '123456789';
+        assert.equal(input.internationalValue, '+(33)1-23-45-67-89');
+      });
+      
+      test('international value is read only', function() {
+        var input = fixture('basic');
+        input.countryCode = '33';
+        input.phoneNumberPattern = 'X-XX-XX-XX-XX';
+        input.value = '123456789';
+        input.internationalValue = '+(32)2-345-67-89';
+        assert.equal(input.internationalValue, '+(33)1-23-45-67-89');
+      });
+
+      test('gets the value without country code if it is not set', function() {
+        var input = fixture('basic');
+        input.countryCode = '';
+        input.phoneNumberPattern = 'X-XX-XX-XX-XX';
+        input.value = '123456789';
+        assert.equal(input.internationalValue, '1-23-45-67-89');
+      });
     });
 
     suite('a11y', function() {


### PR DESCRIPTION
This commit adds a computed property "internationalValue". This new
property is the value prefixed by the country code (if there is one).

fixes #21