### PR TITLE
without the {{value::input}} does not work

### DIFF
--- a/gold-phone-input.html
+++ b/gold-phone-input.html
@@ -167,7 +167,7 @@ style this element.
           autocomplete="tel"
           maxlength="[[maxlength]]"
           name="[[name]]"
-          value="{{value}}"
+          value="{{value::input}}"
           disabled="[[disabled]]"
           autofocus="[[autofocus]]"
           inputmode="[[inputmode]]"


### PR DESCRIPTION
fix a bug