### PR TITLE
fix(binding): fix international value binding

### DIFF
--- a/gold-phone-input.html
+++ b/gold-phone-input.html
@@ -226,6 +226,7 @@ style this element.
        */
       internationalValue: {
         type: String,
+        notify: true,
         computed: '_computeInternationalValue(countryCode, value)'
       }
     },


### PR DESCRIPTION
Before this commit, the property `internationalValue` was only one-way
binding. Others elements watching this value were not aware of the
changes. Now the gold-element-input is using two-way binding on this
property so parents are notified about the changes.

Fixes #83